### PR TITLE
Add Rust-focused agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Codex Agent Instructions
+
+## Scope
+These instructions apply to the entire repository.
+
+## Reasoning
+`pyvcloud`'s Python implementation is deprecated. We are migrating the codebase
+to a Rust library for improved maintainability, performance and safety.
+
+## Principles
+- Follow SOLID and DRY principles when adding or modifying code.
+- Keep commits focused on a single change.
+
+## Commit Guidelines
+- Use concise commit messages in the present tense, e.g. `Add docs`.
+- When editing documentation or code, ensure README and relevant docs remain up to date.
+
+## Testing
+- Before committing, run `cargo fmt -- --check` and `cargo clippy -- -D warnings`.
+- Run `cargo test` for the unit tests.
+- Include the results of these commands in the PR **Testing** section.
+- It's ok if tests fail, but note any failures in the PR summary.
+

--- a/README.md
+++ b/README.md
@@ -2,48 +2,21 @@
 
 [![License](https://img.shields.io/pypi/l/pyvcloud.svg)](https://pypi.python.org/pypi/pyvcloud) [![Stable Version](https://img.shields.io/pypi/v/pyvcloud.svg)](https://pypi.python.org/pypi/pyvcloud) [![Build Status](https://img.shields.io/travis/vmware/pyvcloud.svg?style=flat)](https://travis-ci.org/vmware/pyvcloud/)
 
-`pyvcloud` is the Python SDK for VMware vCloud Director.
+`pyvcloud` started as a Python SDK for VMware vCloud Director. The project is
+now migrating to a Rust implementation for better safety and performance.
 
 Supported API versions are 29.0, 30.0, 31.0, 32.0, 33.0, 34.0, 35.0, 36.0.
 
-## Installation
+## Building
 
-In general, `pyvcloud` can be installed with the following command:
-```shell
-$ pip install --user pyvcloud
-```
-Depending on your operating system and distribution you
-may need additional packages to install successfully. See
-[install.md](docs/install.md) for full details.
-
-## Testing
-
-Contributions to `pyvcloud` are welcome and it should include unit tests. See the [contributing guide](CONTRIBUTING.md) for details.
-
-Check out the latest version and install:
+Development of the Rust version uses the standard cargo workflow. Ensure a
+recent Rust toolchain is installed and run the following to verify the build:
 
 ```shell
-git clone https://github.com/vmware/pyvcloud.git
-cd pyvcloud
-virtualenv .venv
-source .venv/bin/activate
-python setup.py develop
+cargo fmt -- --check
+cargo clippy -- -D warnings
+cargo test
 ```
-
-Sample test parameters are in file [tests/config.yml](tests/config.yml). Create a copy to specify your own settings and use the `VCD_TEST_CONFIG_FILE` env variable.
-
-```shell
-cd tests
-cp config.yml private.config.yml
-# customize credentials and other parameters
-export VCD_TEST_CONFIG_FILE=private.config.yml
-# run unit test
-python -m unittest vcd_login vcd_catalog_setup
-# run just a test method
-python -m unittest vcd_catalog_setup.TestCatalogSetup.test_validate_ova
-```
-
-See [tests](tests/) for a list of current unit tests written for the new SDK implementation.
 
 
 ## Notes
@@ -53,6 +26,10 @@ Please note that this project is under development and the interfaces might chan
 `pyvcloud` is used by [vcd-cli](https://vmware.github.io/vcd-cli), the Command Line Interface for VMware vCloud Director. It requires Python 3.6 or higher.
 
 Previous versions and deprecated code can be found in this repository under [tag 18.2.2](https://github.com/vmware/pyvcloud/tree/18.2.2).
+
+## Migration to Rust
+
+This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles. See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.
 
 ## Contributing
 

--- a/RUST_MIGRATION_CHECKLIST.md
+++ b/RUST_MIGRATION_CHECKLIST.md
@@ -1,0 +1,31 @@
+# Rust Migration Checklist
+
+This document outlines iterative steps to migrate the deprecated `pyvcloud` Python SDK to a Rust library while adhering to SOLID and DRY principles.
+
+- [ ] **Assess Current Python Implementation**
+  - Review existing modules, tests and documentation.
+  - Identify core API surfaces used by consumers.
+- [ ] **Define the Rust Project Structure**
+  - Create a new Rust crate for the library using `cargo new`.
+  - Plan module layout mirroring current Python packages.
+- [ ] **Establish Build & Test Workflow**
+  - Configure `cargo` with continuous integration to run `cargo fmt`, `clippy`, and unit tests.
+  - Set up GitHub Actions or other CI to verify builds across platforms.
+- [ ] **Port Core Functionality**
+  - Translate Python modules to Rust modules iteratively, focusing on clean, idiomatic Rust.
+  - Ensure each ported component has thorough unit tests.
+- [ ] **Wrap REST API Interactions**
+  - Use Rust HTTP libraries (e.g., `reqwest`) to replace Python REST calls.
+  - Provide typed structures and error handling that match vCloud Director APIs.
+- [ ] **Maintain Documentation**
+  - Update `README.md` and docs to explain building and using the Rust crate.
+  - Document each module with Rustdoc comments.
+- [ ] **Verify Feature Parity**
+  - Confirm that all major features from `pyvcloud` are available in the Rust version.
+  - Deprecate old Python code as functionality is replaced.
+- [ ] **Package and Publish**
+  - Publish the crate to [crates.io](https://crates.io/) when stable.
+  - Provide migration notes for existing Python users.
+- [ ] **Iterate and Improve**
+  - Collect feedback, fix issues, and continuously apply SOLID and DRY principles.
+


### PR DESCRIPTION
## Summary
- clarify repository purpose as migrating from Python to Rust
- remove Python instructions from README and describe cargo workflow
- update AGENTS.md with reasoning, SOLID/DRY principles and cargo testing steps

## Testing
- `cargo fmt -- --check` *(fails: cargo-fmt not installed)*
- `cargo clippy -- -D warnings` *(fails: cargo-clippy not installed)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686d7841314c832a8e1df7ae1fcee76d