### PR TITLE
Add extract_id utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Previous versions and deprecated code can be found in this repository under [tag
 
 ## Migration to Rust
 
-This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.  
-The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities.  
+This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
+The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities, such as `extract_id` for parsing URNs.
 See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.
 
 ## Contributing

--- a/pyvcloud-rs/src/lib.rs
+++ b/pyvcloud-rs/src/lib.rs
@@ -1,6 +1,8 @@
 //! Rust implementation for the pyvcloud client. This crate mirrors the
 //! functionality provided by the deprecated Python SDK.
 
+pub mod utils;
+
 /// Prepare a base URI by ensuring the appropriate prefix and path components.
 ///
 /// If `is_cloudapi` is true the "cloudapi" path is appended, otherwise "api"

--- a/pyvcloud-rs/src/utils.rs
+++ b/pyvcloud-rs/src/utils.rs
@@ -1,0 +1,34 @@
+//! Utility functions mirroring deprecated Python helpers.
+
+/// Extract the ID portion of a vCloud urn string.
+///
+/// Example:
+/// `urn:vcloud:catalog:39867ab4-04e0-4b13-b468-08abcc1de810` becomes
+/// `39867ab4-04e0-4b13-b468-08abcc1de810`.
+///
+/// If `urn` is `None` this returns `None`.
+pub fn extract_id(urn: Option<&str>) -> Option<String> {
+    urn.map(|u| u.rsplit(':').next().unwrap_or(u).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_id;
+
+    #[test]
+    fn none_returns_none() {
+        assert_eq!(extract_id(None), None);
+    }
+
+    #[test]
+    fn splits_urn() {
+        let id = extract_id(Some("urn:vcloud:catalog:123"));
+        assert_eq!(id.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn returns_original_when_no_colon() {
+        let id = extract_id(Some("abcd"));
+        assert_eq!(id.as_deref(), Some("abcd"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `utils::extract_id` in Rust
- export the new module in the crate
- mention `extract_id` in README
- add unit tests

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686d7f8c85e4832a87db0b2975759b05