### PR TITLE
Continue library migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Previous versions and deprecated code can be found in this repository under [tag
 ## Migration to Rust
 
 This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
-The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities, such as `extract_id` for parsing URNs.
+The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities, such as `extract_id` for parsing URNs. It also defines an `ApiVersion` enum listing supported vCloud Director API versions.
 See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.
 
 ## Contributing

--- a/pyvcloud-rs/src/lib.rs
+++ b/pyvcloud-rs/src/lib.rs
@@ -2,6 +2,7 @@
 //! functionality provided by the deprecated Python SDK.
 
 pub mod utils;
+pub mod version;
 
 /// Prepare a base URI by ensuring the appropriate prefix and path components.
 ///

--- a/pyvcloud-rs/src/version.rs
+++ b/pyvcloud-rs/src/version.rs
@@ -1,0 +1,88 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiVersion {
+    V29,
+    V30,
+    V31,
+    V32,
+    V33,
+    V34,
+    V35,
+    V36,
+    V37Alpha,
+}
+
+impl ApiVersion {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ApiVersion::V29 => "29.0",
+            ApiVersion::V30 => "30.0",
+            ApiVersion::V31 => "31.0",
+            ApiVersion::V32 => "32.0",
+            ApiVersion::V33 => "33.0",
+            ApiVersion::V34 => "34.0",
+            ApiVersion::V35 => "35.0",
+            ApiVersion::V36 => "36.0",
+            ApiVersion::V37Alpha => "37.0.0-alpha",
+        }
+    }
+}
+
+impl fmt::Display for ApiVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ApiVersion {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "29.0" => Ok(ApiVersion::V29),
+            "30.0" => Ok(ApiVersion::V30),
+            "31.0" => Ok(ApiVersion::V31),
+            "32.0" => Ok(ApiVersion::V32),
+            "33.0" => Ok(ApiVersion::V33),
+            "34.0" => Ok(ApiVersion::V34),
+            "35.0" => Ok(ApiVersion::V35),
+            "36.0" => Ok(ApiVersion::V36),
+            "37.0.0-alpha" => Ok(ApiVersion::V37Alpha),
+            _ => Err(()),
+        }
+    }
+}
+
+pub const API_CURRENT_VERSIONS: &[ApiVersion] = &[
+    ApiVersion::V29,
+    ApiVersion::V30,
+    ApiVersion::V31,
+    ApiVersion::V32,
+    ApiVersion::V33,
+    ApiVersion::V34,
+    ApiVersion::V35,
+    ApiVersion::V36,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version() {
+        let v: ApiVersion = "31.0".parse().unwrap();
+        assert_eq!(v, ApiVersion::V31);
+    }
+
+    #[test]
+    fn display_version() {
+        assert_eq!(ApiVersion::V34.to_string(), "34.0");
+    }
+
+    #[test]
+    fn api_current_versions_length() {
+        assert_eq!(API_CURRENT_VERSIONS.len(), 8);
+    }
+}


### PR DESCRIPTION
## Summary
- define `ApiVersion` enum for Rust library
- document supported API versions in README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686d815c11ac832a89b85a04a9797044