### PR TITLE
Add helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Previous versions and deprecated code can be found in this repository under [tag
 ## Migration to Rust
 
 This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
-The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities, such as `extract_id` for parsing URNs. It also defines an `ApiVersion` enum listing supported vCloud Director API versions.
-Additional networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have been ported as part of the migration.
+The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions.
+Additional networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
 See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.
 
 ## Contributing

--- a/pyvcloud-rs/src/utils.rs
+++ b/pyvcloud-rs/src/utils.rs
@@ -86,11 +86,34 @@ pub fn retrieve_compute_policy_id_from_href(href: &str) -> Option<String> {
     href.rsplit('/').next().map(|s| s.to_string())
 }
 
+/// Convert a duration in seconds to a human readable weeks, days and hours
+/// string in the form `"<weeks>w, <days>d, <hours>h"`.
+pub fn to_human(seconds: u64) -> String {
+    let weeks = seconds / (7 * 24 * 60 * 60);
+    let days = seconds / (24 * 60 * 60) - 7 * weeks;
+    let hours = seconds / (60 * 60) - 7 * 24 * weeks - 24 * days;
+    format!("{}w, {}d, {}h", weeks, days, hours)
+}
+
+/// Map an adapter type number to a display string. Unknown numbers return a
+/// placeholder message.
+pub fn adapter_type_to_name(adapter_type: &str) -> String {
+    match adapter_type {
+        "1" => "IDE".to_string(),
+        "2" => "BusLogic Parallel (SCSI)".to_string(),
+        "3" => "LSI Logic Parallel (SCSI)".to_string(),
+        "4" => "LSI Logic SAS (SCSI)".to_string(),
+        "5" => "Paravirtual (SCSI)".to_string(),
+        "6" => "SATA".to_string(),
+        _ => format!("Adapter Type {}undefined", adapter_type),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        build_network_url_from_gateway_url, cidr_to_netmask, extract_id,
-        netmask_to_cidr_prefix_len, retrieve_compute_policy_id_from_href, uri_to_api_uri,
+        adapter_type_to_name, build_network_url_from_gateway_url, cidr_to_netmask, extract_id,
+        netmask_to_cidr_prefix_len, retrieve_compute_policy_id_from_href, to_human, uri_to_api_uri,
     };
 
     #[test]
@@ -140,5 +163,17 @@ mod tests {
     fn compute_policy_id_from_href() {
         let id = retrieve_compute_policy_id_from_href("https://x/policies/abc").unwrap();
         assert_eq!(id, "abc");
+    }
+
+    #[test]
+    fn seconds_to_human_readable() {
+        assert_eq!(to_human(10_800), "0w, 0d, 3h");
+        assert_eq!(to_human(900_000), "1w, 3d, 10h");
+    }
+
+    #[test]
+    fn adapter_type_lookup() {
+        assert_eq!(adapter_type_to_name("3"), "LSI Logic Parallel (SCSI)".to_string());
+        assert_eq!(adapter_type_to_name("9"), "Adapter Type 9undefined".to_string());
     }
 }


### PR DESCRIPTION
## Summary
- add `to_human` and `adapter_type_to_name` helpers
- update README with helper examples

## Testing
- `cargo fmt --manifest-path pyvcloud-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path pyvcloud-rs/Cargo.toml -- -D warnings`
- `cargo test --manifest-path pyvcloud-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686d999e9d04832aac6014d14a647831