### PR TITLE
Continue migrating enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Previous versions and deprecated code can be found in this repository under [tag
 ## Migration to Rust
 
 This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
-The new Rust crate lives under `pyvcloud-rs` and currently provides a small `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions.
-Additional networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
+A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus` and `VAppPowerStatus` model common vCD concepts.
+Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
 A helper function `get_safe_members_in_tar_file` is available for safely
 extracting archives.
 See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.

--- a/pyvcloud-rs/src/types.rs
+++ b/pyvcloud-rs/src/types.rs
@@ -114,6 +114,219 @@ impl std::str::FromStr for VmNicProperty {
     }
 }
 
+/// Domains used for metadata entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetadataDomain {
+    General,
+    System,
+}
+
+impl std::fmt::Display for MetadataDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            MetadataDomain::General => "GENERAL",
+            MetadataDomain::System => "SYSTEM",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for MetadataDomain {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "GENERAL" => Ok(MetadataDomain::General),
+            "SYSTEM" => Ok(MetadataDomain::System),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Visibility levels for metadata keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetadataVisibility {
+    Private,
+    ReadOnly,
+    ReadWrite,
+}
+
+impl std::fmt::Display for MetadataVisibility {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            MetadataVisibility::Private => "PRIVATE",
+            MetadataVisibility::ReadOnly => "READONLY",
+            MetadataVisibility::ReadWrite => "READWRITE",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for MetadataVisibility {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "PRIVATE" => Ok(MetadataVisibility::Private),
+            "READONLY" => Ok(MetadataVisibility::ReadOnly),
+            "READWRITE" => Ok(MetadataVisibility::ReadWrite),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Possible data types for metadata values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetadataValueType {
+    String,
+    Number,
+    Boolean,
+    DateTime,
+}
+
+impl std::fmt::Display for MetadataValueType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            MetadataValueType::String => "MetadataStringValue",
+            MetadataValueType::Number => "MetadataNumberValue",
+            MetadataValueType::Boolean => "MetadataBooleanValue",
+            MetadataValueType::DateTime => "MetadataDateTimeValue",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for MetadataValueType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "MetadataStringValue" => Ok(MetadataValueType::String),
+            "MetadataNumberValue" => Ok(MetadataValueType::Number),
+            "MetadataBooleanValue" => Ok(MetadataValueType::Boolean),
+            "MetadataDateTimeValue" => Ok(MetadataValueType::DateTime),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Status values for asynchronous tasks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatus {
+    Queued,
+    PreRunning,
+    Running,
+    Success,
+    Error,
+    Canceled,
+    Aborted,
+}
+
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            TaskStatus::Queued => "queued",
+            TaskStatus::PreRunning => "preRunning",
+            TaskStatus::Running => "running",
+            TaskStatus::Success => "success",
+            TaskStatus::Error => "error",
+            TaskStatus::Canceled => "canceled",
+            TaskStatus::Aborted => "aborted",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for TaskStatus {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "queued" => Ok(TaskStatus::Queued),
+            "preRunning" => Ok(TaskStatus::PreRunning),
+            "running" => Ok(TaskStatus::Running),
+            "success" => Ok(TaskStatus::Success),
+            "error" => Ok(TaskStatus::Error),
+            "canceled" => Ok(TaskStatus::Canceled),
+            "aborted" => Ok(TaskStatus::Aborted),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Edge gateway form factor options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayBackingConfigType {
+    Compact,
+    Full,
+    Full4,
+    XLarge,
+}
+
+impl std::fmt::Display for GatewayBackingConfigType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            GatewayBackingConfigType::Compact => "compact",
+            GatewayBackingConfigType::Full => "full",
+            GatewayBackingConfigType::Full4 => "full4",
+            GatewayBackingConfigType::XLarge => "x-large",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for GatewayBackingConfigType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "compact" => Ok(GatewayBackingConfigType::Compact),
+            "full" => Ok(GatewayBackingConfigType::Full),
+            "full4" => Ok(GatewayBackingConfigType::Full4),
+            "x-large" => Ok(GatewayBackingConfigType::XLarge),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Power state values reported for vApps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VAppPowerStatus {
+    Running,
+    Stopped,
+    Suspended,
+    Deployed,
+    Undeployed,
+}
+
+impl std::fmt::Display for VAppPowerStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            VAppPowerStatus::Running => "4",
+            VAppPowerStatus::Stopped => "8",
+            VAppPowerStatus::Suspended => "3",
+            VAppPowerStatus::Deployed => "2",
+            VAppPowerStatus::Undeployed => "1",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for VAppPowerStatus {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "4" => Ok(VAppPowerStatus::Running),
+            "8" => Ok(VAppPowerStatus::Stopped),
+            "3" => Ok(VAppPowerStatus::Suspended),
+            "2" => Ok(VAppPowerStatus::Deployed),
+            "1" => Ok(VAppPowerStatus::Undeployed),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Return the vCloud status message for a given status code.
 pub fn vcloud_status_message(status: i32) -> Option<&'static str> {
     match status {
@@ -171,5 +384,26 @@ mod tests {
     #[test]
     fn status_message_unknown() {
         assert_eq!(vcloud_status_message(42), None);
+    }
+
+    #[test]
+    fn parse_metadata_domain() {
+        let d: MetadataDomain = "GENERAL".parse().unwrap();
+        assert_eq!(d, MetadataDomain::General);
+        assert_eq!(d.to_string(), "GENERAL");
+    }
+
+    #[test]
+    fn parse_task_status() {
+        let s: TaskStatus = "running".parse().unwrap();
+        assert_eq!(s, TaskStatus::Running);
+        assert_eq!(s.to_string(), "running");
+    }
+
+    #[test]
+    fn parse_vapp_power_status() {
+        let p: VAppPowerStatus = "4".parse().unwrap();
+        assert_eq!(p, VAppPowerStatus::Running);
+        assert_eq!(p.to_string(), "4");
     }
 }

--- a/pyvcloud-rs/src/utils.rs
+++ b/pyvcloud-rs/src/utils.rs
@@ -112,7 +112,6 @@ pub fn adapter_type_to_name(adapter_type: &str) -> String {
     }
 }
 
-
 /// Normalize a path by removing `.` and `..` components without touching the
 /// filesystem.
 fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
@@ -231,9 +230,9 @@ pub fn get_admin_extension_href(href: &str) -> String {
 mod tests {
     use super::{
         adapter_type_to_name, build_network_url_from_gateway_url, cidr_to_netmask, extract_id,
-        bad_link, bad_path, get_admin_extension_href, get_admin_href, get_non_admin_href,
-        get_safe_members_in_tar_file, is_admin, netmask_to_cidr_prefix_len,
-        retrieve_compute_policy_id_from_href, to_human, uri_to_api_uri,
+        get_admin_extension_href, get_admin_href, get_non_admin_href, get_safe_members_in_tar_file,
+        is_admin, netmask_to_cidr_prefix_len, retrieve_compute_policy_id_from_href, to_human,
+        uri_to_api_uri,
     };
 
     #[test]
@@ -348,7 +347,7 @@ mod tests {
     #[test]
     fn safe_members_filters_illegal_paths() {
         use std::io::Cursor;
-        use tar::{Archive, Builder, Header, EntryType};
+        use tar::{Archive, Builder, EntryType, Header};
 
         let mut data = Vec::new();
         {


### PR DESCRIPTION
## Summary
- document metadata and task enums in the README
- port metadata and task enums from Python
- test enum parsing

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686dbd55aa88832a8aa98cb324ee2bbf