### PR TITLE
Continue migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This Python implementation of `pyvcloud` is deprecated. Development is moving to
 A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus` and `VAppPowerStatus` model common vCD concepts.
 Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
 A helper function `get_safe_members_in_tar_file` is available for safely
-extracting archives.
+extracting archives. Utility `to_camel_case` assists with case-insensitive name
+matching.
 See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.
 
 ## Contributing

--- a/pyvcloud-rs/src/utils.rs
+++ b/pyvcloud-rs/src/utils.rs
@@ -112,6 +112,18 @@ pub fn adapter_type_to_name(adapter_type: &str) -> String {
     }
 }
 
+/// Return the canonical name from `names` matching `name` case-insensitively.
+///
+/// If no match is found `name` is returned as-is.
+pub fn to_camel_case(name: &str, names: &[&str]) -> String {
+    for n in names {
+        if name.eq_ignore_ascii_case(n) {
+            return (*n).to_string();
+        }
+    }
+    name.to_string()
+}
+
 /// Normalize a path by removing `.` and `..` components without touching the
 /// filesystem.
 fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
@@ -231,8 +243,8 @@ mod tests {
     use super::{
         adapter_type_to_name, build_network_url_from_gateway_url, cidr_to_netmask, extract_id,
         get_admin_extension_href, get_admin_href, get_non_admin_href, get_safe_members_in_tar_file,
-        is_admin, netmask_to_cidr_prefix_len, retrieve_compute_policy_id_from_href, to_human,
-        uri_to_api_uri,
+        is_admin, netmask_to_cidr_prefix_len, retrieve_compute_policy_id_from_href, to_camel_case,
+        to_human, uri_to_api_uri,
     };
 
     #[test]
@@ -377,5 +389,12 @@ mod tests {
         let mut archive = Archive::new(Cursor::new(data));
         let members = get_safe_members_in_tar_file(&mut archive).unwrap();
         assert_eq!(members, vec![String::from("safe.txt")]);
+    }
+
+    #[test]
+    fn camel_case_lookup() {
+        let names = ["FooBar", "BazQuux"];
+        assert_eq!(to_camel_case("foobar", &names), "FooBar".to_string());
+        assert_eq!(to_camel_case("nomatch", &names), "nomatch".to_string());
     }
 }


### PR DESCRIPTION
## Summary
- support case-insensitive name matching via `to_camel_case`
- document new helper in README
- test `to_camel_case`

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686dbf930e14832abecded3c721d9671