### PR TITLE
Add VcdApiVersion struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Previous versions and deprecated code can be found in this repository under [tag
 
 This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
 A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus` and `VAppPowerStatus` model common vCD concepts.
+A struct `VcdApiVersion` provides comparison logic for pre-release API versions matching the behavior of the old Python SDK.
 Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
 A helper function `get_safe_members_in_tar_file` is available for safely
 extracting archives. Utility `to_camel_case` assists with case-insensitive name

--- a/pyvcloud-rs/Cargo.lock
+++ b/pyvcloud-rs/Cargo.lock
@@ -63,6 +63,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 name = "pyvcloud-rs"
 version = "0.1.0"
 dependencies = [
+ "semver",
  "tar",
 ]
 
@@ -87,6 +88,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "tar"

--- a/pyvcloud-rs/Cargo.toml
+++ b/pyvcloud-rs/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 tar = "0.4"
+semver = "1"

--- a/pyvcloud-rs/src/lib.rs
+++ b/pyvcloud-rs/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod types;
 pub mod utils;
+pub mod vcd_api_version;
 pub mod version;
 
 /// Prepare a base URI by ensuring the appropriate prefix and path components.

--- a/pyvcloud-rs/src/vcd_api_version.rs
+++ b/pyvcloud-rs/src/vcd_api_version.rs
@@ -1,0 +1,139 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::str::FromStr;
+
+/// Representation of a vCloud Director API version.
+///
+/// Pre-release versions are considered equal if they share the same base
+/// version and pre-release label regardless of the numeric suffix. This
+/// mirrors the behaviour of the Python `VCDApiVersion` class.
+#[derive(Debug, Clone)]
+pub struct VcdApiVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    original: String,
+    pre: Option<String>,
+    label: Option<String>,
+}
+
+impl VcdApiVersion {
+    fn base_cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch))
+    }
+
+    fn full_cmp(&self, other: &Self) -> Ordering {
+        match self.base_cmp(other) {
+            Ordering::Equal => match (&self.pre, &other.pre) {
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(a), Some(b)) => a.cmp(b),
+            },
+            o => o,
+        }
+    }
+
+    /// Return true if this is a pre-release version.
+    pub fn is_prerelease(&self) -> bool {
+        self.pre.is_some()
+    }
+}
+
+impl FromStr for VcdApiVersion {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let original = s.to_string();
+        let (base, pre) = if let Some(idx) = s.find('-') {
+            (&s[..idx], Some(&s[idx + 1..]))
+        } else {
+            (s, None)
+        };
+        let mut numbers = base.split('.');
+        let major: u32 = numbers.next().ok_or(())?.parse().map_err(|_| ())?;
+        let minor: u32 = numbers.next().unwrap_or("0").parse().map_err(|_| ())?;
+        let patch: u32 = numbers.next().unwrap_or("0").parse().map_err(|_| ())?;
+        let pre_owned = pre.map(|p| p.to_string());
+        let label = pre.map(|p| p.split('-').next().unwrap_or(p).to_string());
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            original,
+            pre: pre_owned,
+            label,
+        })
+    }
+}
+
+impl fmt::Display for VcdApiVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.original)
+    }
+}
+
+impl PartialEq for VcdApiVersion {
+    fn eq(&self, other: &Self) -> bool {
+        if self.is_prerelease()
+            && other.is_prerelease()
+            && self.base_cmp(other) == Ordering::Equal
+            && self.label == other.label
+        {
+            true
+        } else {
+            self.major == other.major
+                && self.minor == other.minor
+                && self.patch == other.patch
+                && self.pre == other.pre
+        }
+    }
+}
+
+impl Eq for VcdApiVersion {}
+
+impl PartialOrd for VcdApiVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VcdApiVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.is_prerelease()
+            && other.is_prerelease()
+            && self.base_cmp(other) == Ordering::Equal
+            && self.label == other.label
+        {
+            Ordering::Equal
+        } else {
+            self.full_cmp(other)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prerelease_label_equality() {
+        let a: VcdApiVersion = "37.0.0-alpha-1".parse().unwrap();
+        let b: VcdApiVersion = "37.0.0-alpha-2".parse().unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prerelease_vs_release() {
+        let a: VcdApiVersion = "37.0.0-alpha-1".parse().unwrap();
+        let b: VcdApiVersion = "37.0.0".parse().unwrap();
+        assert!(a < b);
+    }
+
+    #[test]
+    fn ordering_different_base() {
+        let a: VcdApiVersion = "36.0".parse().unwrap();
+        let b: VcdApiVersion = "37.0.0-alpha".parse().unwrap();
+        assert!(a < b);
+    }
+}


### PR DESCRIPTION
## Summary
- add VcdApiVersion struct for flexible API version comparison
- expose new module in lib
- add semver dependency
- document the new struct in the README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686dd0f85324832aa7ac986049f1f1db