### PR TITLE
Continue Rust migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Previous versions and deprecated code can be found in this repository under [tag
 ## Migration to Rust
 
 This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
-A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus` and `VAppPowerStatus` model common vCD concepts.
+A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus`, `VAppPowerStatus`, `FenceMode`, `LogicalNetworkLinkType` and `NetworkAdapterType` model common vCD concepts.
 A struct `VcdApiVersion` provides comparison logic for pre-release API versions matching the behavior of the old Python SDK.
 Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
 A helper function `get_safe_members_in_tar_file` is available for safely

--- a/pyvcloud-rs/src/types.rs
+++ b/pyvcloud-rs/src/types.rs
@@ -327,6 +327,114 @@ impl std::str::FromStr for VAppPowerStatus {
     }
 }
 
+/// Supported network fence modes for vApp networks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FenceMode {
+    Isolated,
+    Direct,
+    Bridged,
+    NatRouted,
+}
+
+impl std::fmt::Display for FenceMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            FenceMode::Isolated => "isolated",
+            FenceMode::Direct => "direct",
+            FenceMode::Bridged => "bridged",
+            FenceMode::NatRouted => "natRouted",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for FenceMode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "isolated" => Ok(FenceMode::Isolated),
+            "direct" => Ok(FenceMode::Direct),
+            "bridged" => Ok(FenceMode::Bridged),
+            "natRouted" => Ok(FenceMode::NatRouted),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Types of logical network links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogicalNetworkLinkType {
+    Bridged,
+    Independent,
+    DlrUplink,
+}
+
+impl std::fmt::Display for LogicalNetworkLinkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            LogicalNetworkLinkType::Bridged => "0",
+            LogicalNetworkLinkType::Independent => "1",
+            LogicalNetworkLinkType::DlrUplink => "2",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for LogicalNetworkLinkType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0" => Ok(LogicalNetworkLinkType::Bridged),
+            "1" => Ok(LogicalNetworkLinkType::Independent),
+            "2" => Ok(LogicalNetworkLinkType::DlrUplink),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Virtual network adapter models.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkAdapterType {
+    Vmxnet,
+    Vmxnet2,
+    Vmxnet3,
+    E1000,
+    E1000e,
+    Vlance,
+}
+
+impl std::fmt::Display for NetworkAdapterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            NetworkAdapterType::Vmxnet => "VMXNET",
+            NetworkAdapterType::Vmxnet2 => "VMXNET2",
+            NetworkAdapterType::Vmxnet3 => "VMXNET3",
+            NetworkAdapterType::E1000 => "E1000",
+            NetworkAdapterType::E1000e => "E1000E",
+            NetworkAdapterType::Vlance => "PCNet32",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for NetworkAdapterType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "VMXNET" => Ok(NetworkAdapterType::Vmxnet),
+            "VMXNET2" => Ok(NetworkAdapterType::Vmxnet2),
+            "VMXNET3" => Ok(NetworkAdapterType::Vmxnet3),
+            "E1000" => Ok(NetworkAdapterType::E1000),
+            "E1000E" => Ok(NetworkAdapterType::E1000e),
+            "PCNet32" => Ok(NetworkAdapterType::Vlance),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Return the vCloud status message for a given status code.
 pub fn vcloud_status_message(status: i32) -> Option<&'static str> {
     match status {
@@ -405,5 +513,26 @@ mod tests {
         let p: VAppPowerStatus = "4".parse().unwrap();
         assert_eq!(p, VAppPowerStatus::Running);
         assert_eq!(p.to_string(), "4");
+    }
+
+    #[test]
+    fn parse_fence_mode() {
+        let f: FenceMode = "bridged".parse().unwrap();
+        assert_eq!(f, FenceMode::Bridged);
+        assert_eq!(f.to_string(), "bridged");
+    }
+
+    #[test]
+    fn parse_logical_network_link_type() {
+        let t: LogicalNetworkLinkType = "1".parse().unwrap();
+        assert_eq!(t, LogicalNetworkLinkType::Independent);
+        assert_eq!(t.to_string(), "1");
+    }
+
+    #[test]
+    fn parse_network_adapter_type() {
+        let t: NetworkAdapterType = "VMXNET3".parse().unwrap();
+        assert_eq!(t, NetworkAdapterType::Vmxnet3);
+        assert_eq!(t.to_string(), "VMXNET3");
     }
 }


### PR DESCRIPTION
## Summary
- implement network enums in Rust
- mention new enums in README
- run cargo fmt/clippy/test

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e6e6a05a4832ab71ce3a96eeaa304