### PR TITLE
Continue migration to Rust constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This Python implementation of `pyvcloud` is deprecated. Development is moving to
 A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus`, `VAppPowerStatus`, `FenceMode`, `LogicalNetworkLinkType`, `NetworkAdapterType`, `RelationType`, `ResourceType` and `QueryResultFormat` model common vCD concepts.
 A struct `VcdApiVersion` provides comparison logic for pre-release API versions matching the behavior of the old Python SDK.
 Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
+A `network_constants` module exposes REST endpoint templates such as `FIREWALL_URL_TEMPLATE` for constructing URLs programmatically.
 A helper function `get_safe_members_in_tar_file` is available for safely
 extracting archives. Utility `to_camel_case` assists with case-insensitive name
 matching.

--- a/pyvcloud-rs/src/lib.rs
+++ b/pyvcloud-rs/src/lib.rs
@@ -1,6 +1,7 @@
 //! Rust implementation for the pyvcloud client. This crate mirrors the
 //! functionality provided by the deprecated Python SDK.
 
+pub mod network_constants;
 pub mod types;
 pub mod utils;
 pub mod vcd_api_version;

--- a/pyvcloud-rs/src/network_constants.rs
+++ b/pyvcloud-rs/src/network_constants.rs
@@ -1,0 +1,40 @@
+//! Constants mirroring network URL templates from the Python SDK.
+
+/// Base firewall configuration path.
+pub const FIREWALL_URL_TEMPLATE: &str = "/firewall/config";
+/// Firewall rules collection path.
+pub const FIREWALL_RULES_URL_TEMPLATE: &str = "/firewall/config/rules";
+/// Firewall rule item path template.
+pub const FIREWALL_RULE_URL_TEMPLATE: &str = "/firewall/config/rules/{0}";
+
+/// Base DHCP configuration path.
+pub const DHCP_URL_TEMPLATE: &str = "/dhcp/config";
+/// DHCP pools collection path.
+pub const DHCP_POOLS_URL_TEMPLATE: &str = "/dhcp/config/ippools";
+/// DHCP pool item path template.
+pub const DHCP_POOL_URL_TEMPLATE: &str = "/dhcp/config/ippools/{0}";
+
+/// DHCP bindings collection path.
+pub const DHCP_BINDINGS_URL_TEMPLATE: &str = "/dhcp/config/staticBindings";
+/// DHCP binding item path template.
+pub const DHCP_BINDING_URL_TEMPLATE: &str = "/dhcp/config/staticBindings/{0}";
+
+/// Base NAT configuration path.
+pub const NAT_URL_TEMPLATE: &str = "/nat/config";
+/// NAT rules collection path.
+pub const NAT_RULES_URL_TEMPLATE: &str = "/nat/config/rules";
+/// NAT rule item path template.
+pub const NAT_RULE_URL_TEMPLATE: &str = "/nat/config/rules/{0}";
+
+/// Static routing configuration path.
+pub const STATIC_ROUTE_URL_TEMPLATE: &str = "/routing/config/static";
+/// IPsec VPN configuration path.
+pub const IPSEC_VPN_URL_TEMPLATE: &str = "/ipsec/config";
+/// Endpoint to upload service certificates.
+pub const SERVICE_CERTIFICATE_POST: &str = "/services/truststore/certificate/";
+/// Endpoint to upload certificate revocation lists.
+pub const CRL_CERTIFICATE_POST: &str = "/services/truststore/crl/";
+/// Endpoint to retrieve certificates scoped by resource.
+pub const GET_CERTIFICATES: &str = "/services/truststore/certificate/scope/";
+/// Endpoint to retrieve CRLs scoped by resource.
+pub const GET_CRL_CERTIFICATES: &str = "/services/truststore/crl/scope/";


### PR DESCRIPTION
## Summary
- add network constants module in Rust crate
- export the module
- mention new module in README

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686ea7abd7a8832a870fa341cf129f16