### PR TITLE
Continue migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ Previous versions and deprecated code can be found in this repository under [tag
 
 This Python implementation of `pyvcloud` is deprecated. Development is moving toward a Rust-based library that follows SOLID and DRY principles.
 A small Rust crate lives under `pyvcloud-rs` providing a `Client` struct and helper utilities. Examples include `extract_id` for parsing URNs, `to_human` for formatting durations and `adapter_type_to_name` for displaying VM adapter types. The crate also defines an `ApiVersion` enum listing supported vCloud Director API versions. Additional enums such as `MetadataDomain`, `MetadataVisibility`, `TaskStatus`, `VAppPowerStatus`, `FenceMode`, `LogicalNetworkLinkType`, `NetworkAdapterType`, `RelationType`, `ResourceType`, `EntityType`, `WellKnownEndpoint` and `QueryResultFormat` model common vCD concepts.
-A struct `VcdApiVersion` provides comparison logic for pre-release API versions matching the behavior of the old Python SDK.
+A struct `VcdApiVersion` provides comparison logic for pre-release API versions
+matching the behavior of the old Python SDK. A helper
+`vcd_api_current_versions` returns the list of supported `VcdApiVersion`
+objects.
 Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration.
 A `compute_policy` module offers constants such as `VDC_COMPUTE_POLICY_MIN_API_VERSION` and a helper `generate_compute_policy_tags` for constructing compute policy XML snippets.
 A `network_constants` module exposes REST endpoint templates such as `FIREWALL_URL_TEMPLATE` for constructing URLs programmatically.

--- a/RUST_MIGRATION_CHECKLIST.md
+++ b/RUST_MIGRATION_CHECKLIST.md
@@ -14,6 +14,7 @@ This document outlines iterative steps to migrate the deprecated `pyvcloud` Pyth
 - [ ] **Port Core Functionality**
   - Translate Python modules to Rust modules iteratively, focusing on clean, idiomatic Rust.
   - Ensure each ported component has thorough unit tests.
+  - Ported API version helpers including `vcd_api_current_versions`.
 - [ ] **Wrap REST API Interactions**
   - Use Rust HTTP libraries (e.g., `reqwest`) to replace Python REST calls.
   - Provide typed structures and error handling that match vCloud Director APIs.

--- a/pyvcloud-rs/src/vcd_api_version.rs
+++ b/pyvcloud-rs/src/vcd_api_version.rs
@@ -112,6 +112,22 @@ impl Ord for VcdApiVersion {
     }
 }
 
+/// Return a list of `VcdApiVersion` objects representing the currently
+/// supported API versions.
+pub fn vcd_api_current_versions() -> Vec<VcdApiVersion> {
+    vec![
+        "29.0".parse().unwrap(),
+        "30.0".parse().unwrap(),
+        "31.0".parse().unwrap(),
+        "32.0".parse().unwrap(),
+        "33.0".parse().unwrap(),
+        "34.0".parse().unwrap(),
+        "35.0".parse().unwrap(),
+        "36.0".parse().unwrap(),
+        "37.0.0-alpha".parse().unwrap(),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,5 +151,12 @@ mod tests {
         let a: VcdApiVersion = "36.0".parse().unwrap();
         let b: VcdApiVersion = "37.0.0-alpha".parse().unwrap();
         assert!(a < b);
+    }
+
+    #[test]
+    fn list_current_versions() {
+        let versions = vcd_api_current_versions();
+        assert_eq!(versions.len(), 9);
+        assert_eq!(versions[0].to_string(), "29.0");
     }
 }


### PR DESCRIPTION
## Summary
- provide function to list supported `VcdApiVersion`s
- mention new helper in the README
- update migration checklist

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ecc0d4fe8832ab17c1d903677ec34