### PR TITLE
Add XML formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ A `compute_policy` module offers constants such as `VDC_COMPUTE_POLICY_MIN_API_V
 A `network_constants` module exposes REST endpoint templates such as `FIREWALL_URL_TEMPLATE` for constructing URLs programmatically.
 A helper function `get_safe_members_in_tar_file` is available for safely
 extracting archives. Utility `to_camel_case` assists with case-insensitive name
-matching.
+matching. The `stdout_xml` helper prints XML to the console with optional
+highlighting.
 See [RUST_MIGRATION_CHECKLIST.md](RUST_MIGRATION_CHECKLIST.md) for an overview of the migration plan and progress.
 
 ## Contributing

--- a/pyvcloud-rs/Cargo.lock
+++ b/pyvcloud-rs/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,9 +69,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "pyvcloud-rs"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "semver",
  "tar",
 ]
@@ -75,6 +91,35 @@ checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"

--- a/pyvcloud-rs/Cargo.toml
+++ b/pyvcloud-rs/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 tar = "0.4"
 semver = "1"
+regex = "1"

--- a/pyvcloud-rs/src/utils.rs
+++ b/pyvcloud-rs/src/utils.rs
@@ -124,6 +124,31 @@ pub fn to_camel_case(name: &str, names: &[&str]) -> String {
     name.to_string()
 }
 
+/// Return a string representation of XML with optional ANSI color
+/// highlighting for element tags.
+pub fn format_xml(xml: &str, colorized: bool) -> String {
+    if !colorized {
+        return xml.to_string();
+    }
+    let re = regex::Regex::new(r"</?[^>]+>").unwrap();
+    let mut out = String::new();
+    let mut last = 0;
+    for mat in re.find_iter(xml) {
+        out.push_str(&xml[last..mat.start()]);
+        out.push_str("\x1b[34m");
+        out.push_str(mat.as_str());
+        out.push_str("\x1b[0m");
+        last = mat.end();
+    }
+    out.push_str(&xml[last..]);
+    out
+}
+
+/// Print XML to stdout with optional highlighting of element tags.
+pub fn stdout_xml(xml: &str, colorized: bool) {
+    println!("{}", format_xml(xml, colorized));
+}
+
 /// Normalize a path by removing `.` and `..` components without touching the
 /// filesystem.
 fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
@@ -242,9 +267,9 @@ pub fn get_admin_extension_href(href: &str) -> String {
 mod tests {
     use super::{
         adapter_type_to_name, build_network_url_from_gateway_url, cidr_to_netmask, extract_id,
-        get_admin_extension_href, get_admin_href, get_non_admin_href, get_safe_members_in_tar_file,
-        is_admin, netmask_to_cidr_prefix_len, retrieve_compute_policy_id_from_href, to_camel_case,
-        to_human, uri_to_api_uri,
+        format_xml, get_admin_extension_href, get_admin_href, get_non_admin_href,
+        get_safe_members_in_tar_file, is_admin, netmask_to_cidr_prefix_len,
+        retrieve_compute_policy_id_from_href, to_camel_case, to_human, uri_to_api_uri,
     };
 
     #[test]
@@ -396,5 +421,17 @@ mod tests {
         let names = ["FooBar", "BazQuux"];
         assert_eq!(to_camel_case("foobar", &names), "FooBar".to_string());
         assert_eq!(to_camel_case("nomatch", &names), "nomatch".to_string());
+    }
+
+    #[test]
+    fn format_xml_no_color() {
+        let xml = "<foo></foo>";
+        assert_eq!(format_xml(xml, false), xml);
+    }
+
+    #[test]
+    fn format_xml_color_changes_output() {
+        let xml = "<foo></foo>";
+        assert_ne!(format_xml(xml, true), xml);
     }
 }


### PR DESCRIPTION
## Summary
- expose `stdout_xml` and `format_xml` helpers in Rust utils
- colorize XML element tags using ANSI escape codes
- document new helper in README

## Testing
- `cargo fmt --manifest-path pyvcloud-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path pyvcloud-rs/Cargo.toml -- -D warnings`
- `cargo test --manifest-path pyvcloud-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686ed4c0fe24832abb205b654c51d042