### PR TITLE
Continue Rust migration

### DIFF
--- a/pyvcloud-rs/Cargo.lock
+++ b/pyvcloud-rs/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "roxmltree",
  "semver",
  "tar",
+ "xmltree",
 ]
 
 [[package]]
@@ -1594,10 +1595,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
 
 [[package]]
 name = "yoke"

--- a/pyvcloud-rs/Cargo.toml
+++ b/pyvcloud-rs/Cargo.toml
@@ -9,3 +9,4 @@ semver = "1"
 regex = "1"
 roxmltree = "0.18"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
+xmltree = "0.10"

--- a/pyvcloud-rs/src/compute_policy.rs
+++ b/pyvcloud-rs/src/compute_policy.rs
@@ -60,6 +60,148 @@ pub fn generate_compute_policy_tags(
     }
 }
 
+/// Update the compute policy portion of a VM XML document.
+///
+/// The provided XML must represent a `<Vm>` element. When compute policy
+/// information is added or modified, the function returns `true` and the VM
+/// element is updated in place. When no change is required `false` is returned.
+pub fn update_vm_compute_policy_element(
+    api_version: f32,
+    vm: &mut xmltree::Element,
+    sizing_policy_href: Option<&str>,
+    sizing_policy_final: bool,
+    placement_policy_href: Option<&str>,
+    placement_policy_final: bool,
+) -> bool {
+    if api_version < VM_SIZING_POLICY_MIN_API_VERSION
+        && sizing_policy_href.is_none()
+        && placement_policy_href.is_none()
+    {
+        return false;
+    }
+
+    let mut updated = false;
+    let date_index = vm
+        .children
+        .iter()
+        .position(|c| matches!(c, xmltree::XMLNode::Element(e) if e.name == "DateCreated"));
+
+    let mut cp_index = vm
+        .children
+        .iter()
+        .position(|c| matches!(c, xmltree::XMLNode::Element(e) if e.name == "ComputePolicy"));
+
+    if cp_index.is_none() {
+        let cp_elem = xmltree::Element::new("ComputePolicy");
+        let insert_at = date_index.unwrap_or(vm.children.len());
+        vm.children
+            .insert(insert_at, xmltree::XMLNode::Element(cp_elem));
+        cp_index = Some(insert_at);
+        updated = true;
+    }
+
+    let cp_elem = match vm.children.get_mut(cp_index.unwrap()) {
+        Some(xmltree::XMLNode::Element(e)) => e,
+        _ => unreachable!(),
+    };
+
+    if let Some(href) = placement_policy_href {
+        let mut policy_elem = cp_elem
+            .get_mut_child("VmPlacementPolicy")
+            .cloned()
+            .unwrap_or_else(|| {
+                updated = true;
+                xmltree::Element::new("VmPlacementPolicy")
+            });
+        if policy_elem.attributes.get("href") != Some(&href.to_string()) {
+            policy_elem
+                .attributes
+                .insert("href".into(), href.to_string());
+            updated = true;
+        }
+        let id = retrieve_compute_policy_id_from_href(href).unwrap_or_default();
+        if policy_elem.attributes.get("id") != Some(&id) {
+            policy_elem.attributes.insert("id".into(), id);
+            updated = true;
+        }
+        policy_elem
+            .attributes
+            .insert("type".into(), "application/json".into());
+
+        if cp_elem.get_mut_child("VmPlacementPolicy").is_none() {
+            let pos = 0;
+            cp_elem
+                .children
+                .insert(pos, xmltree::XMLNode::Element(policy_elem.clone()));
+            cp_elem.children.insert(
+                pos + 1,
+                xmltree::XMLNode::Element(xmltree::Element {
+                    prefix: None,
+                    namespace: None,
+                    namespaces: None,
+                    name: "VmPlacementPolicyFinal".into(),
+                    attributes: std::collections::HashMap::new(),
+                    children: vec![xmltree::XMLNode::Text(if placement_policy_final {
+                        "true".into()
+                    } else {
+                        "false".into()
+                    })],
+                }),
+            );
+        } else {
+            *cp_elem.get_mut_child("VmPlacementPolicy").unwrap() = policy_elem;
+        }
+    }
+
+    if let Some(href) = sizing_policy_href {
+        let mut policy_elem = cp_elem
+            .get_mut_child("VmSizingPolicy")
+            .cloned()
+            .unwrap_or_else(|| {
+                updated = true;
+                xmltree::Element::new("VmSizingPolicy")
+            });
+        if policy_elem.attributes.get("href") != Some(&href.to_string()) {
+            policy_elem
+                .attributes
+                .insert("href".into(), href.to_string());
+            updated = true;
+        }
+        let id = retrieve_compute_policy_id_from_href(href).unwrap_or_default();
+        if policy_elem.attributes.get("id") != Some(&id) {
+            policy_elem.attributes.insert("id".into(), id);
+            updated = true;
+        }
+        policy_elem
+            .attributes
+            .insert("type".into(), "application/json".into());
+
+        if cp_elem.get_mut_child("VmSizingPolicy").is_none() {
+            cp_elem
+                .children
+                .push(xmltree::XMLNode::Element(policy_elem.clone()));
+            cp_elem
+                .children
+                .push(xmltree::XMLNode::Element(xmltree::Element {
+                    prefix: None,
+                    namespace: None,
+                    namespaces: None,
+                    name: "VmSizingPolicyFinal".into(),
+                    attributes: std::collections::HashMap::new(),
+                    children: vec![xmltree::XMLNode::Text(if sizing_policy_final {
+                        "true".into()
+                    } else {
+                        "false".into()
+                    })],
+                }));
+        } else {
+            *cp_elem.get_mut_child("VmSizingPolicy").unwrap() = policy_elem;
+        }
+    }
+
+    updated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +229,36 @@ mod tests {
             compute.unwrap(),
             "<ComputePolicy><VmPlacementPolicy href=\"https://x/policies/p1\" id=\"p1\" /><VmSizingPolicy href=\"https://x/policies/s1\" id=\"s1\" /></ComputePolicy>"
         );
+    }
+
+    #[test]
+    fn update_vm_compute_policy() {
+        let xml = "<Vm><DateCreated>now</DateCreated></Vm>";
+        let mut elem = xmltree::Element::parse(xml.as_bytes()).unwrap();
+        let changed = update_vm_compute_policy_element(
+            34.0,
+            &mut elem,
+            Some("https://x/policies/s1"),
+            true,
+            Some("https://x/policies/p1"),
+            false,
+        );
+        assert!(changed);
+        let mut buf = Vec::new();
+        elem.write(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("VmPlacementPolicy"));
+        assert!(out.contains("VmSizingPolicy"));
+
+        // Reapply with same data should yield no changes
+        let changed_again = update_vm_compute_policy_element(
+            34.0,
+            &mut elem,
+            Some("https://x/policies/s1"),
+            true,
+            Some("https://x/policies/p1"),
+            false,
+        );
+        assert!(!changed_again);
     }
 }


### PR DESCRIPTION
## Summary
- add XML editing for VM compute policy updates
- pull in xmltree crate
- format and lint

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ef46e2d40832aa26ea12d7de95f85