### PR TITLE
Continue migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A struct `VcdApiVersion` provides comparison logic for pre-release API versions
 matching the behavior of the old Python SDK. A helper
 `vcd_api_current_versions` returns the list of supported `VcdApiVersion`
 objects.
-Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration. A `BasicLoginCredentials` struct stores user, organization and password values. Constants such as `SIZE_1MB`, `SYSTEM_ORG_NAME` and `ALPHA_API_SUBSTRING` mirror common values from the Python client.
+Networking helpers like `cidr_to_netmask`, `uri_to_api_uri`, `build_network_url_from_gateway_url` and `retrieve_compute_policy_id_from_href` have also been ported as part of the migration. A `BasicLoginCredentials` struct stores user, organization and password values. Constants such as `SIZE_1MB`, `SYSTEM_ORG_NAME`, `ALPHA_API_SUBSTRING`, `HEADERS_TO_REDACT` and `UPLOAD_FRAGMENT_MAX_RETRIES` mirror common values from the Python client.
 A utility `filter_attributes` returns common attribute names for selected `ResourceType` values.
 A `compute_policy` module offers constants such as `VDC_COMPUTE_POLICY_MIN_API_VERSION` and a helper `generate_compute_policy_tags` for constructing compute policy XML snippets.
 A `network_constants` module exposes REST endpoint templates such as `FIREWALL_URL_TEMPLATE` for constructing URLs programmatically.

--- a/pyvcloud-rs/src/client.rs
+++ b/pyvcloud-rs/src/client.rs
@@ -9,6 +9,46 @@ pub const SYSTEM_ORG_NAME: &str = "system";
 /// Substring used for alpha API versions.
 pub const ALPHA_API_SUBSTRING: &str = "alpha";
 
+/// Standard HTTP header names used by the client.
+pub const HEADER_ACCEPT_NAME: &str = "Accept";
+pub const HEADER_AUTHORIZATION_NAME: &str = "Authorization";
+pub const HEADER_CONNECTION_NAME: &str = "Connection";
+pub const HEADER_CONTENT_LENGTH_NAME: &str = "Content-Length";
+pub const HEADER_CONTENT_RANGE_NAME: &str = "Content-Range";
+pub const HEADER_CONTENT_TYPE_NAME: &str = "Content-Type";
+pub const HEADER_REQUEST_ID_NAME: &str = "X-VMWARE-VCLOUD-REQUEST-ID";
+pub const HEADER_X_VCLOUD_AUTH_NAME: &str = "x-vcloud-authorization";
+pub const HEADER_X_VMWARE_CLOUD_ACCESS_TOKEN_NAME: &str = "x-vmware-vcloud-access-token";
+
+/// Value used to close HTTP connections.
+pub const HEADER_CONNECTION_VALUE_CLOSE: &str = "close";
+
+/// Headers whose values should be redacted when logging.
+pub const HEADERS_TO_REDACT: &[&str] = &[
+    HEADER_AUTHORIZATION_NAME,
+    HEADER_X_VCLOUD_AUTH_NAME,
+    HEADER_X_VMWARE_CLOUD_ACCESS_TOKEN_NAME,
+];
+
+/// Maximum number of retries when uploading file fragments.
+pub const UPLOAD_FRAGMENT_MAX_RETRIES: u8 = 5;
+
+/// Return a copy of `headers` with sensitive values replaced by "[REDACTED]".
+pub fn redact_headers(
+    headers: &std::collections::HashMap<String, String>,
+) -> std::collections::HashMap<String, String> {
+    headers
+        .iter()
+        .map(|(k, v)| {
+            if HEADERS_TO_REDACT.iter().any(|h| h.eq_ignore_ascii_case(k)) {
+                (k.clone(), "[REDACTED]".to_string())
+            } else {
+                (k.clone(), v.clone())
+            }
+        })
+        .collect()
+}
+
 /// Basic set of credentials containing organisation, user and password.
 #[derive(Debug, Clone)]
 pub struct BasicLoginCredentials {
@@ -46,5 +86,18 @@ mod tests {
     fn display_obscures_password() {
         let creds = BasicLoginCredentials::new("user", "org", "secret");
         assert_eq!(creds.to_string(), "user@org");
+    }
+
+    #[test]
+    fn redact_sensitive_headers() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert(HEADER_AUTHORIZATION_NAME.to_string(), "token".to_string());
+        headers.insert("Content-Type".to_string(), "text/plain".to_string());
+        let redacted = redact_headers(&headers);
+        assert_eq!(
+            redacted.get(HEADER_AUTHORIZATION_NAME).unwrap(),
+            "[REDACTED]"
+        );
+        assert_eq!(redacted.get("Content-Type").unwrap(), "text/plain");
     }
 }

--- a/pyvcloud-rs/src/types.rs
+++ b/pyvcloud-rs/src/types.rs
@@ -1404,17 +1404,18 @@ impl VCloudStatus {
             VCloudStatus::UnrecognizedState => "Unrecognized state",
             VCloudStatus::PoweredOff => "Powered off",
             VCloudStatus::InconsistentState => "Inconsistent state",
-            VCloudStatus::ChildrenDoNotAllHaveSameStatus =>
-                "Children do not all have the same status",
-            VCloudStatus::UploadInitiatedOvfDescriptorPending =>
-                "Upload initiated, OVF descriptor pending",
-            VCloudStatus::UploadInitiatedCopyingContents =>
-                "Upload initiated, copying contents",
-            VCloudStatus::UploadInitiatedDiskContentsPending =>
-                "Upload initiated , disk contents pending",
+            VCloudStatus::ChildrenDoNotAllHaveSameStatus => {
+                "Children do not all have the same status"
+            }
+            VCloudStatus::UploadInitiatedOvfDescriptorPending => {
+                "Upload initiated, OVF descriptor pending"
+            }
+            VCloudStatus::UploadInitiatedCopyingContents => "Upload initiated, copying contents",
+            VCloudStatus::UploadInitiatedDiskContentsPending => {
+                "Upload initiated , disk contents pending"
+            }
             VCloudStatus::UploadQuarantined => "Upload has been quarantined",
-            VCloudStatus::UploadQuarantineExpired =>
-                "Upload quarantine period has expired",
+            VCloudStatus::UploadQuarantineExpired => "Upload quarantine period has expired",
         }
     }
 


### PR DESCRIPTION
## Summary
- add HTTP header utilities and constants
- update README with new constants
- format codebase with `cargo fmt`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fabe533c0832a8d98f1c8154d3ca3