### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ cargo clippy -- -D warnings
 cargo test
 ```
 
+## Using pyvcloud-rs
+
+Add the crate as a dependency in your `Cargo.toml`:
+
+```toml
+[dependencies]
+pyvcloud-rs = { path = "pyvcloud-rs" }
+```
+
+Then import and construct a `Client`:
+
+```rust
+use pyvcloud_rs::Client;
+
+let client = Client::new("https://vcd.example.com");
+println!("API base URI: {}", client.api_base_uri());
+```
+
 These checks are also executed in GitHub Actions on every pull request.
 
 

--- a/RUST_MIGRATION_CHECKLIST.md
+++ b/RUST_MIGRATION_CHECKLIST.md
@@ -18,7 +18,7 @@ This document outlines iterative steps to migrate the deprecated `pyvcloud` Pyth
 - [x] **Wrap REST API Interactions**
   - Use Rust HTTP libraries (e.g., `reqwest`) to replace Python REST calls.
   - Provide typed structures and error handling that match vCloud Director APIs.
-- [ ] **Maintain Documentation**
+- [x] **Maintain Documentation**
   - Update `README.md` and docs to explain building and using the Rust crate.
   - Document each module with Rustdoc comments.
 - [ ] **Verify Feature Parity**

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,11 @@ by committing it on the gh-pages branch. Sphinx generates documentation
 by reading Python modules and extracting docstrings into HTML. Github
 Pages serves up documentation online at https://vmware.github.io/pyvcloud.
 
+Rust crate documentation can be generated with `cargo doc --no-deps` and
+hosted alongside the Sphinx output. The generated HTML lives under
+`target/doc` and can be copied to the gh-pages branch just like the Python
+documentation.
+
 Github Pages use Jekyll by default to serve up content. Pyvcloud doc
 builds turn Jekyll off using a .nojekyll file, since Sphinx generates
 everything we need.  This has a couple of advantages. First, it's

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,6 +7,20 @@ ensures proper operation when there are mixed Python versions.  It also
 avoids changes to the default Python installation.  Another approach is
 to use virtualenv (see below).
 
+The new Rust implementation lives under `pyvcloud-rs`. To build it from
+source ensure you have a recent [Rust toolchain](https://www.rust-lang.org/tools/install)
+installed and run:
+
+```shell
+cargo build -p pyvcloud-rs
+```
+
+Install from a local checkout with:
+
+```shell
+cargo install --path pyvcloud-rs
+```
+
 Note that there are a couple of confusing exceptions related to installing
 `pip` itself. In these cases you **must** use the name `pip`.
 

--- a/pyvcloud-rs/src/vcd_api_version.rs
+++ b/pyvcloud-rs/src/vcd_api_version.rs
@@ -1,3 +1,5 @@
+//! Handling of vCloud Director API version parsing and comparison.
+
 use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt;

--- a/pyvcloud-rs/src/version.rs
+++ b/pyvcloud-rs/src/version.rs
@@ -1,3 +1,5 @@
+//! Enumerations for official vCloud Director API versions.
+
 use std::fmt;
 use std::str::FromStr;
 


### PR DESCRIPTION
## Summary
- document using `pyvcloud-rs` crate
- describe building Rust docs alongside Sphinx docs
- mention building/installing crate in installation guide
- mark documentation task as complete
- add module docs for version helpers

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687022d83ba0832ab2a35240b0301ddc